### PR TITLE
Add a makefile.

### DIFF
--- a/Documentation/Compiling.txt
+++ b/Documentation/Compiling.txt
@@ -2,6 +2,10 @@
 
 ====COMPILING.TXT====
 
+On Linux, run the Makefile:
+    make
+or otherwise execute the following individual steps:
+
 1.  Get your compiler version:    
         javac -version
     and enter the version on line 19 of B4constants.java where it will become available

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Name of the jarfile.
+JARNAME=BEAM4.jar
+
+# Java version number.
+JAVAVER=$(shell javac -version 2>&1)
+STR="s/\(^    static final String  COMPILER   = \"Compiler was: \).*\(\";.*$$\)/\1${JAVAVER}\2/g"
+	
+all:
+	@# Replace Java version number string in source code.
+	sed -i ${STR} Sources/B4constants.java
+	
+	@# Compile java files.
+	javac -Xlint Sources/*.java
+
+	@# Create jar archive.
+	install -d com/stellarsoftware/beam/
+	install -D Sources/*.class com/stellarsoftware/beam/
+	jar cfe "${JARNAME}" com.stellarsoftware.beam.B4 com/
+
+clean:
+	rm -rf Sources/*.class com/


### PR DESCRIPTION
This makefile works with GNU make on Linux. It also clarifies the directory structure needed for the Java manifest, which was previously far from obvious in the documentation.
