### PR TITLE
Thin perfect lens implementation to allow for afocal design

### DIFF
--- a/Sources/AutoAdj.java
+++ b/Sources/AutoAdj.java
@@ -6,7 +6,7 @@ import javax.swing.*;
 
 
 /** AutoAdj.java
-  *
+  * A207: eliminated groups
   * class LMadj is at the bottom of this file. 
   * A190, Nov 2015: introducing weights.
   * @author: M.Lampton (c) 2003..2006 STELLAR SOFTWARE all rights reserved.
@@ -22,7 +22,7 @@ class AdjHost implements B4constants
     //----------parallel with InOut-------------
     private OEJIF optEditor = null; 
     private REJIF rayEditor = null; 
-    private int nsurfs=0, ngroups=0, nrays=0, onfields=0, rnfields=0;
+    private int nsurfs=0, nrays=0, onfields=0, rnfields=0;
     private int npts, nadj=0, onadj=0, rnadj=0, ngood=0, autongoals=0; 
     private boolean bWFE=false; 
 
@@ -58,11 +58,10 @@ class AdjHost implements B4constants
         rayEditor.doStashForUndo(); 
         
         nsurfs = DMF.giFlags[ONSURFS]; 
-        ngroups = DMF.giFlags[ONGROUPS]; 
         onfields = DMF.giFlags[ONFIELDS];  // fields per optic.
         nrays = DMF.giFlags[RNRAYS]; 
         rnfields = DMF.giFlags[RNFIELDS];  // fields per ray.
-        if ((ngroups<1) || (onfields<1) || (nrays<1) || (rnfields<1))
+        if ((onfields<1) || (nrays<1) || (rnfields<1))
           return;          // SNH graying. 
           
         bWFE = DMF.giFlags[RWFEFIELD] > RABSENT; 
@@ -173,17 +172,13 @@ class AdjHost implements B4constants
             int j = optEditor.getAdjSurf(iadj);
             if ((j>0) && (j<=nsurfs))
             {
-                int g = RT13.group[j]; 
-                if ((g>0) && (g<=ngroups))
-                {
-                    for (int kray=1; kray<=nrays; kray++)
-                      if (RT13.bGoodRay[kray])
-                      {
-                          double rx = RT13.dGetRay(kray, g, RTXL); 
-                          double ry = RT13.dGetRay(kray, g, RTYL); 
-                          r = Math.max(r, Math.sqrt(rx*rx+ry*ry)); 
-                      }
-                }
+                for (int kray=1; kray<=nrays; kray++)
+                  if (RT13.isRayOK[kray])
+                  {
+                      double rx = RT13.dGetRay(kray, j, RTXL); 
+                      double ry = RT13.dGetRay(kray, j, RTYL); 
+                      r = Math.max(r, Math.sqrt(rx*rx+ry*ry)); 
+                  }
             }
             if (r < 1E-6)
               r = 0.5*dOsize; 
@@ -299,7 +294,7 @@ class AdjHost implements B4constants
         if (istatus==BADITER)
         {
             if (DMF.sAutoErr.equals(""))   // no previous message
-              jL[7].setText("Ray risk. Stopping.");
+              jL[7].setText("Stopping: " + sResults[RT13.getFailCode()] + " " + RT13.getFailSurf());  
             else                           // retain previous message
               jL[7].setText(DMF.sAutoErr); 
         }
@@ -361,7 +356,7 @@ class AdjHost implements B4constants
                 }
 
                 if (op == RDEBUG) // debugger message here....
-                  rayEditor.putField(f, row, RT13.bGoodRay[kray] ? "OK" : "NG"); 
+                  rayEditor.putField(f, row, RT13.isRayOK[kray] ? "OK" : "NG"); 
 
 
                 if (op >= RGOAL) // Comparo updates floating goals, not Auto.
@@ -369,11 +364,11 @@ class AdjHost implements B4constants
 
                 if (op >= 100)   // output table data are wanted here...
                 {
-                    int jsurf = RT13.getGroupNum(op); // handles "final"
+                    int jsurf = RT13.getSurfNum(op); // handles "final"
                     int iattr = RT13.getAttrNum(op); 
                     if ((iattr>=0) && (iattr<RNATTRIBS) && (jsurf>0))
                     {
-                        if (RT13.bGoodRay[kray])
+                        if (RT13.isRayOK[kray])
                         {
                             double d = RT13.dGetRay(kray, jsurf, iattr); 
                             rayEditor.putFieldDouble(f, row, d);  

--- a/Sources/B4constants.java
+++ b/Sources/B4constants.java
@@ -517,7 +517,7 @@ interface B4constants
     static final int OZ33      = 113; 
     static final int OZ34      = 114; 
     static final int OZ35      = 115; 
-    static final int OFOCAL    = 116; //focal length of thin lens
+    static final int ODIOP    = 116; //focal length of thin lens
     static final int OFINALADJ = 117; // final autoadjustable parameter
 
     static final int OTIRINDEX = 121;

--- a/Sources/B4constants.java
+++ b/Sources/B4constants.java
@@ -383,7 +383,8 @@ interface B4constants
     static final int OZ33      = 83; 
     static final int OZ34      = 84; 
     static final int OZ35      = 85; 
-    static final int OFINALADJ = 86; // final autoadjustable parameter
+    static final int OFOCAL    = 86; //focal length of thin lens
+    static final int OFINALADJ = 87; // final autoadjustable parameter
 
     static final int OTIRINDEX = 91;
     static final int OODIAOBS  = 92; // observed from trace
@@ -417,8 +418,7 @@ interface B4constants
     static final int OTYPE     = 120; // 0=lens, 1=mirror, 2=iris...
     static final int OFORM     = 121; // 0=ellip, 1=rect...
     static final int OPROFILE  = 122; // 0=plane, 1=conic...
-    static final int OFOCAL    = 123; //focal length of thin lens
-    static final int ONPARMS   = 124; // array size.
+    static final int ONPARMS   = 123; // array size.
 
 /*-------------OTABLE strings for OEJIF diagnostic-----------*/
 

--- a/Sources/B4constants.java
+++ b/Sources/B4constants.java
@@ -417,7 +417,8 @@ interface B4constants
     static final int OTYPE     = 120; // 0=lens, 1=mirror, 2=iris...
     static final int OFORM     = 121; // 0=ellip, 1=rect...
     static final int OPROFILE  = 122; // 0=plane, 1=conic...
-    static final int ONPARMS   = 123; // array size.
+    static final int OFOCAL    = 123; //focal length of thin lens
+    static final int ONPARMS   = 124; // array size.
 
 /*-------------OTABLE strings for OEJIF diagnostic-----------*/
 
@@ -456,7 +457,8 @@ interface B4constants
     static final int OTCBOUT     = 10; // coordinate break output
     static final int OTBLFRONT   = 11; // bimodal lens front
     static final int OTBLBACK    = 12; // bimodal lens back
-    static final int OTUNK       = 13; // unknown type; SNH.
+    static final int OTTHIN      = 13; // perfect thin lens
+    static final int OTUNK       = 14; // unknown type; SNH.
 
     // phantom is merely an OTLENS with equal indices.
 
@@ -474,6 +476,7 @@ interface B4constants
     "cbOutput",  // 10
     "bilens_f",  // 11  bimodal lens front surface
     "bilens_r",  // 12  bimodal lens rear surface
+    "thin",      // 13  perfect thin lens
     "unknown"};  // 11  SNH
 
 /*-----------OPROFILE attributes and strings------------------*/

--- a/Sources/B4constants.java
+++ b/Sources/B4constants.java
@@ -3,23 +3,30 @@ package com.stellarsoftware.beam;
 import java.awt.*;   // Color
 
 /**
-  * B4constants.java  -- an interface carrying static global constants.
-  * 
-  * 
+  * B4constants.java  -- an interface carrying static global constants
+  *  A207: attempting logic cleanup for bimodal optics
+  *  A206: Converting all mirrors into bimodal mirrors, never killing rays
+  *  A205: Autoadjust ray failure now announces surface & failure classification
+  *  A204: fix the spider layout artwork (spider FUNCTIONS okay). 
+  *  A203: allow "asphericity" as well as previous "asph"; see OEJIF line 800.
+  *  A202 wider editor fields. 
+  *  A201  Sept 2017 has user selected skeleton parameters for new files. 
   *  All fields here are public static final. (H&C p.206)
   *  Added RTANGLE between ray and normal any surface, March 2015, Oct 2015.
   *  Added RTNORMX, RTNORMY, RTNORMZ as new ray attributes. 
   *  Added lower case i, j, k to read out the surface normal vector. 
-  *
-  *  @author M.Lampton STELLAR SOFTWARE (c) 2004-2014 all rights reserved.
+  *  Added OSGAUSS for 2D circular Gaussian shaped surface profile
+  *  Added user selectable new file skeleton options  A201
+  *  @author M.Lampton STELLAR SOFTWARE (c) 2004-2016 all rights reserved.
   */
 interface B4constants
-{
+{    
     static final String  PRODUCT    = "BEAM FOUR  "; 
-    static final String  RELEASE    = "Release 190, 13 January 2016";
-    // fill in your compiler below... "Compiler was: Javac 1.6.0_65" for user compatibility
-    static final String  COMPILER   = "Compiler was: Javac 1.6.0_65";
-    static final String  COPYRIGHT  = "(c) 2016 Stellar Software"; 
+    static final String  RELEASE    = "Release 208,  15 Jan 2019";
+    static final String  COMPILER   = "Compiler was: Javac 1.8.0_20";
+    static final String  COPYRIGHT  = "(c) 2018 Stellar Software"; 
+    static final boolean DEBUG      = false; 
+    
     static final char    NULLCHAR   = (char) 0;
     
     static final int BLINKMILLISEC      = 300; // millisec
@@ -48,15 +55,17 @@ interface B4constants
     static final int THINLINE       = 0;
     static final int FATLINE        = 1;
 
-    static final int IMAX           = 256;       // EPanel charTable
-    static final int JMAX           = 3600;      // EPanel charTable
+    static final int IMAX           = 512;       // Chars EPanel charTable
+    static final int JMAX           = 3600;      // Rows EPanel charTable
     static final int MAXFIELDS      = 100;
     static final int MAXSURFS       = 100;       // < JMAX
-    static final int MAXGROUPS      = MAXSURFS;  
+    // static final int MAXGROUPS      = MAXSURFS;  
     static final int MAXRAYS        = JMAX-3;    // < JMAX
+    // note: 17 circles = 919 rays; 34 rings = 3571 rays.
+    static final int MAXRINGS       = (int) (-0.5+Math.sqrt(12*MAXRAYS-3.)/6.);
     static final int MAXMEDIA       = 200;       // < JMAX
     static final int MAXGOALS       = 7;         // AutoAdjust
-    static final int MAXWFEGROUPS   = 100; 
+    // static final int MAXWFEGROUPS   = 100; 
     static final int MAXADJ         = 100; 
     static final int MAXMAP         = 100;  
     static final int MAXMP          = 9;      // multiplots per axis
@@ -124,7 +133,7 @@ interface B4constants
     static final double MAXSIZE      = 1.5e+6; // plot & layout sanity?
     static final double DENSE        = 1.60;   // heavy if refraction>DENSE
     static final double PLOTTICKFRAC = 0.015;  // plot iristick/opticspan
-    static final double DOTTEDFRAC   = 0.04;   // extension/opticspan
+    // static final double DOTTEDFRAC   = 0.04;   // extension/opticspan
     static final double TICKHEIGHT   = 0.015;  // rulerticks/unitsquare
 
 /*---------------LMITER constants-------------------------*/
@@ -148,50 +157,112 @@ interface B4constants
     static final String RAYSTARTCHARS = "XYZUVWxyzuvw"; // for MapPanel
 
 
-/*-------------------RunRay Tstring[] codes------------*/
+/*-------------------RunRay Tstring[] error codes---------------*/
+/*-----these could be simplified going to a 4x4 SURFxRAY plan---*/
+/*---have them pure ray errors, not mingled with surface IDs----*/
 
-    static final int RROK  =  0;    // general no-failure code
+    static final int RROK  =  0;    // general no-failure error code
+    
     static final int RRMIS =  1;    // ray missed surface.
     static final int RRBAK =  2;    // ray intercepted but behind start.
-    static final int RRBRA =  3;    // propagation fail bracket
-    static final int RRPRP =  4;    // general propagation failure
-    static final int RRUNK =  5;    // unknown diffraction wavelength or other.
-    static final int RRORD =  6;    // redirection fail diffraction order
-    static final int RRTIR =  7;    // redirection fail total internal reflection
-    static final int RRDIA =  8;    // non-Iris Diameter
-    static final int RRdia =  9;    // non-Iris diameter
-    static final int RRIRI = 10;    // Iris OD fail
-    static final int RRiri = 11;    // Iris ID fail 
-    static final int RRSPI = 12;    // spider leg
-    static final int RRARR = 13;    // array setup invalid
-    static final int RRGRP = 14;    // group failed 
-    static final int RRBI  = 15;    // bimodal inner diam intercept
-    static final int RRBO  = 16;    // bimodal outer Diam intercept
-    static final int RRNON = 17;    // not implemented    
+    static final int RRBRA =  3;    // bracket intercept fail
+    
+    static final int RRDIA =  4;    // Diameter: obj or iris
+    
+    static final int RRdia =  5;    // inner diameter: obj or iris
+    static final int RRSPI =  6;    // spider leg    
+    
+    static final int RRORD =  7;    // redirection fail diffraction order
+    static final int RRTIR =  8;    // redirection fail total internal reflection
+    static final int RRARR =  9;    // array setup invalid
+    static final int RRBXO = 10;    // bimodal crossover failure
+    static final int RRTER = 11;    // terminate the trace at redirect() stage
+    static final int RRUNK = 12;    // unknown or blf/blm, or not implemented    
     
     // sResults[] are used by InOut to explain result[]
+    // Needs a special code for NonNumericalWavelength.
     static final String[] sResults = {   
     "OK",        // 0
     "mis",       // 1
     "bak",       // 2
     "bra",       // 3
-    "pro",       // 4
-    "unk",       // 5
-    "ord",       // 6
-    "TIR",       // 7
-    "Dia",       // 8
-    "dia",       // 9
-    "Iri",       // 10
-    "iri",       // 11
-    "spi",       // 12
-    "arr",       // 13
-    "Grp",       // 14
-    
-    "BiI",       // 15
-    "BiO",       // 16
-    "non"};      // 17
+    "Dia",       // 4
+    "dia",       // 5
+    "Spi",       // 6
+    "Ord",       // 7
+    "TIR",       // 8
+    "Arr",       // 9
+    "BXO",       // 10
+    "Ter",       // 11
+    "Unk"};      // 12
    
+    // the 22 codex values are listed here...
+    static final int UNIOK = 0; 
+    static final int UNIIF = 1;
+    static final int UNIPO = 2; // Pupil Outside fail
+    static final int UNIPI = 3; // Pupil Inside fail
+    static final int UNIRF = 4; // Redirection Failure
+    
+    static final int BMOK  = 5;
+    static final int BMIF  = 6;
+    static final int BMPO  = 7; 
+    static final int BMPI  = 8; 
+    static final int BMRF  = 9; 
+    
+    static final int BLFOK = 10;
+    static final int BLFIF = 11; 
+    static final int BLFPO = 12; 
+    static final int BLFPI = 13; 
+    static final int BLFRF = 14;
+    
+    static final int BLBOK = 15;
+    static final int BLBIF = 16; 
+    static final int BLBPO = 17;
+    static final int BLBPI = 18;
+    static final int BLBRF = 19; 
+    
+    static final int BTOK  = 20; // bimodal terminator ray hit & kill 
+    static final int BTIF  = 21; //
+    static final int BTPO  = 22;
+    static final int BTPI  = 23;
+    static final int BTRF  = 24; 
+    
+    static final int BLBXO = 25;  // bimpdal crossover failure 
+    
+    static final int CODEXMULT = 5; // since 5 categories of ray failures
 
+    static final String[] sCodex = {
+    "UNIOK",    // 0
+    "UNIIF",    // 1
+    "UNIPO",    // 2
+    "UNIPI",    // 3
+    "UNIRF",    // 4
+    
+    "BMOK",     // 5
+    "BMIF",     // 6
+    "BMPO",     // 7
+    "BMPI",     // 8
+    "BMRF",     // 9
+    
+    "BLFOK",    // 10
+    "BLFIF",    // 11
+    "BLFPO",    // 12
+    "BLFPI",    // 13
+    "BLFRF",    // 14
+    
+    "BLBOK",    // 15
+    "BLBIF",    // 16
+    "BLBPO",    // 17
+    "BLBPI",    // 18
+    "BLBRF",    // 19
+    
+    "BTOK",     // 20  bimodal terminator ray hit & kill
+    "BTIF",     // 21  bimodal terminator ray miss & bypass
+    "BTPO",     // 22  bimodal terminator ray OD bypass
+    "BTPI",     // 23  bimodal terminator ray ID bypass
+    "BTRF",     // 24  bimodal terminator ray redirect fail: SNH
+    
+    "BLBXO"};   // 25 bimodal crossover failure
 
 
 /*------------ generic editor status[] index macro defs ------------*/
@@ -207,7 +278,7 @@ interface B4constants
     static final int OPRESENT         = 0; // 0=absent=FALSE, 1=present=TRUE
     static final int ONLINES          = 1; // generic
     static final int ONSURFS          = 2; // generic
-    static final int ONGROUPS         = 3; // new; testing...
+    // static final int ONGROUPS         = 3; // new; testing...
     static final int ONFIELDS         = 4; // generic
     static final int OMEDIANEEDED     = 5; // 0=FALSE=okWithout, 1=TRUE=needsMedia.
     static final int OGRATINGPRESENT  = 6; // 1=present 
@@ -291,7 +362,7 @@ interface B4constants
     "OK"};                                 // 16
 
 
-/*----------------------optics table column attributes-------------*/
+/*----------------------optics table column attribute fields-------------*/
 
     static final int OABSENT   = -1; 
     static final int OREFRACT  =  1; // refractive index approaching surface j
@@ -331,93 +402,156 @@ interface B4constants
     static final int OA13      = 32;
     static final int OA14      = 33;
 
-    static final int OGX       = 34; // any of this set triggers GROOVY
-    static final int OGY       = 35;
-    static final int OORDER    = 36; 
-    static final int OVLS1     = 37;
-    static final int OVLS2     = 38;
-    static final int OVLS3     = 39;
-    static final int OVLS4     = 40;
-    static final int OHOEX1    = 41;
-    static final int OHOEY1    = 42;
-    static final int OHOEZ1    = 43;
-    static final int OHOEX2    = 44;
-    static final int OHOEY2    = 45;
-    static final int OHOEZ2    = 46;
-    static final int OHOELAM   = 47;
-    static final int OGROOVY   = 48; 
+
+
     
-    static final int OZ00      = 50; // Zernike coefficient 0: piston
-    static final int OZ01      = 51;
-    static final int OZ02      = 52; 
-    static final int OZ03      = 53; 
-    static final int OZ04      = 54; 
-    static final int OZ05      = 55; 
-    static final int OZ06      = 56; 
-    static final int OZ07      = 57; 
-    static final int OZ08      = 58; 
-    static final int OZ09      = 59; 
-    static final int OZ10      = 60; 
-    static final int OZ11      = 61; 
-    static final int OZ12      = 62; 
-    static final int OZ13      = 63; 
-    static final int OZ14      = 64; 
-    static final int OZ15      = 65; 
-    static final int OZ16      = 66; 
-    static final int OZ17      = 67; 
-    static final int OZ18      = 68; 
-    static final int OZ19      = 69; 
-    static final int OZ20      = 70; 
-    static final int OZ21      = 71; 
-    static final int OZ22      = 72; 
-    static final int OZ23      = 73; 
-    static final int OZ24      = 74; 
-    static final int OZ25      = 75; 
-    static final int OZ26      = 76; 
-    static final int OZ27      = 77; 
-    static final int OZ28      = 78; 
-    static final int OZ29      = 79; 
-    static final int OZ30      = 80; 
-    static final int OZ31      = 81; 
-    static final int OZ32      = 82; 
-    static final int OZ33      = 83; 
-    static final int OZ34      = 84; 
-    static final int OZ35      = 85; 
-    static final int OFINALADJ = 86; // final autoadjustable parameter
+/* =======HETTRICK  22 MARCH 2016==========
+   
+   So, in summary, I (personally) would be happy as a clam with the 
+   following (minimized) number of inputs:
+  
+   Gy, VY01, VY02, VY03, Gx, VX10, VX20, VX30,
+   VY10, VY20, VY30, VY11, VY12, VY21
 
-    static final int OTIRINDEX = 91;
-    static final int OODIAOBS  = 92; // observed from trace
-    static final int OIDIAM    = 93; // used by parser only
-    static final int OIDIAX    = 94; // used by clients
-    static final int OIDIAY    = 95; // used by clients
-    static final int OODIAM    = 96; // used by parser only
-    static final int OODIAX    = 97; // used by clients
-    static final int OODIAY    = 98; // used by clients
-    static final int OZMIN     = 99;
-    static final int OZMAX     = 100;
-    static final int OFFOX     = 101; // offset from vertex
-    static final int OFFOY     = 102; // offset from vertex
-    static final int OFFIX     = 103; // offset from vertex
-    static final int OFFIY     = 104; // offset from vertex
-    static final int OSCATTER  = 105; // introduced Aug 2011 A128
-    static final int ONSPIDER  = 106; // number of spider legs
-    static final int OWSPIDER  = 107; // width of spider leg
-    static final int ONARRAYX  = 108;
-    static final int ONARRAYY  = 109; 
+   Then BEAM4 internally uses the following formula to determine the 
+   corresponding 6 constants needed for computing dN/dx:
 
-    static final int OE11      = 111; // Eulers computed by OEJIF parser
-    static final int OE12      = 112; // These convert lab to local.
-    static final int OE13      = 113; // For local to lab, use transpose. 
-    static final int OE21      = 114;
-    static final int OE22      = 115;
-    static final int OE23      = 116;
-    static final int OE31      = 117;
-    static final int OE32      = 118;
-    static final int OE33      = 119;
-    static final int OTYPE     = 120; // 0=lens, 1=mirror, 2=iris...
-    static final int OFORM     = 121; // 0=ellip, 1=rect...
-    static final int OPROFILE  = 122; // 0=plane, 1=conic...
-    static final int ONPARMS   = 123; // array size.
+   VX(i,j) = [(i+1)/j] * VY(i+1,j-1)  for  all  j .ne. 0
+
+   resulting in the following:
+
+   VX01 = VY10
+   VX02 = 1/2 VY11
+   VX03 = 1/3 VY12
+   VX11 = 2 VY20
+   VX12 = VY21
+   VX21 = 3 VY30    
+   
+   ==== added 4-5 June 2016: fourth power ====
+    Know what?
+    Numbers are cheap.
+    I'll stick in the whole group going to power-sum = 4:
+    VX40, VY40, VY04, VY13, VY22, VY31 user specifiable via .OPT
+    plus internally calculated  VX13, VX22, VX31, VX04.
+*/    
+
+    static final int OORDER    = 34;  // any of this group triggers OGROOVY; see OEJIF.
+    static final int OGX       = 35;  // explicit; user synonyms "GX" or "VX00"
+    static final int OGY       = 36;  // explicit; user synonyms "GY" or "VY00"
+
+    static final int OVX01     = 37;  // implicit; see RT13::setEulers().
+    static final int OVX02     = 38;  // implicit
+    static final int OVX03     = 39;  // implicit
+    static final int OVX04     = 40;  // implicit
+    static final int OVX10     = 41;  // "VX10"; straight groove
+    static final int OVX11     = 42;  // implicit
+    static final int OVX12     = 43;  // implicit
+    static final int OVX13     = 44;  // implicit
+    static final int OVX20     = 45;  // "VX20"; straight groove
+    static final int OVX21     = 46;  // implicit
+    static final int OVX22     = 47;  // implicit
+    static final int OVX30     = 48;  // "VX30"; straight groove
+    static final int OVX31     = 49;  // implicit
+    static final int OVX40     = 50;  // "VX40"; straight groove
+    
+    static final int OVY01     = 51;  // "VY01"; straight groove
+    static final int OVY02     = 52;  // "VY02"; straight groove
+    static final int OVY03     = 53;  // "VY03"; straight groove
+    static final int OVY04     = 54;  // "VY04"; straight groove
+    static final int OVY10     = 55;  // "VY10"
+    static final int OVY11     = 56;  // "VY11"
+    static final int OVY12     = 57;  // "VY12"
+    static final int OVY13     = 58;  // "VY13"
+    static final int OVY20     = 59;  // "VY20"
+    static final int OVY21     = 60;  // "VY21"
+    static final int OVY22     = 61;  // "VY22"
+    static final int OVY30     = 62;  // "VY30"
+    static final int OVY31     = 63;  // "VY31"
+    static final int OVY40     = 64;  // "VY40"
+    
+    static final int ORGAUSS   = 65;  // rms radius of circular Gaussian
+    static final int OHGAUSS   = 66;  // peak height of circular Gaussian
+    
+    static final int OHOEX1    = 71;
+    static final int OHOEY1    = 72;
+    static final int OHOEZ1    = 73;
+    static final int OHOEX2    = 74;
+    static final int OHOEY2    = 75;
+    static final int OHOEZ2    = 76;
+    static final int OHOELAM   = 77;
+    static final int OGROOVY   = 78; // OGX to OHOELAM nonzero set this groovy flag.
+    
+    static final int OZ00      = 80; // Zernike coefficient 0: piston
+    static final int OZ01      = 81;
+    static final int OZ02      = 82; 
+    static final int OZ03      = 83; 
+    static final int OZ04      = 84; 
+    static final int OZ05      = 85; 
+    static final int OZ06      = 86; 
+    static final int OZ07      = 87; 
+    static final int OZ08      = 88; 
+    static final int OZ09      = 89; 
+    static final int OZ10      = 90; 
+    static final int OZ11      = 91; 
+    static final int OZ12      = 92; 
+    static final int OZ13      = 93; 
+    static final int OZ14      = 94; 
+    static final int OZ15      = 95; 
+    static final int OZ16      = 96; 
+    static final int OZ17      = 97; 
+    static final int OZ18      = 98; 
+    static final int OZ19      = 99; 
+    static final int OZ20      = 100; 
+    static final int OZ21      = 101; 
+    static final int OZ22      = 102; 
+    static final int OZ23      = 103; 
+    static final int OZ24      = 104; 
+    static final int OZ25      = 105; 
+    static final int OZ26      = 106; 
+    static final int OZ27      = 107; 
+    static final int OZ28      = 108; 
+    static final int OZ29      = 109; 
+    static final int OZ30      = 110; 
+    static final int OZ31      = 111; 
+    static final int OZ32      = 112; 
+    static final int OZ33      = 113; 
+    static final int OZ34      = 114; 
+    static final int OZ35      = 115; 
+    static final int OFINALADJ = 116; // final autoadjustable parameter
+
+    static final int OTIRINDEX = 121;
+    static final int OODIAOBS  = 122; // observed from trace
+    static final int OIDIAM    = 123; // used by parser only
+    static final int OIDIAX    = 124; // used by clients
+    static final int OIDIAY    = 125; // used by clients
+    static final int OODIAM    = 126; // used by parser only
+    static final int OODIAX    = 127; // used by clients
+    static final int OODIAY    = 128; // used by clients
+    static final int OZMIN     = 129;
+    static final int OZMAX     = 130;
+    static final int OFFOX     = 131; // offset from vertex
+    static final int OFFOY     = 132; // offset from vertex
+    static final int OFFIX     = 133; // offset from vertex
+    static final int OFFIY     = 134; // offset from vertex
+    static final int OSCATTER  = 135; // scatter angle field degrees, Aug 2011 A128;  also A195.  
+    static final int ONSPIDER  = 137; // number of spider legs
+    static final int OWSPIDER  = 138; // width of spider leg
+    static final int ONARRAYX  = 139;
+    static final int ONARRAYY  = 140; 
+
+    static final int OE11      = 141; // Eulers computed by OEJIF parser
+    static final int OE12      = 142; // These convert lab to local.
+    static final int OE13      = 143; // For local to lab, use transpose. 
+    static final int OE21      = 144;
+    static final int OE22      = 145;
+    static final int OE23      = 146;
+    static final int OE31      = 147;
+    static final int OE32      = 148;
+    static final int OE33      = 149;
+    static final int OTYPE     = 150; // 0=lens, 1=mirror, 2=iris...
+    static final int OFORM     = 151; // 0=ellip, 1=rect...
+    static final int OPROFILE  = 152; // 0=plane, 1=conic...
+    static final int ONPARMS   = 153; // array size.
 
 /*-------------OTABLE strings for OEJIF diagnostic-----------*/
 
@@ -451,14 +585,20 @@ interface B4constants
     static final int OTLENSARRAY = 5; 
     static final int OTMIRRARRAY = 6; 
     static final int OTIRISARRAY = 7; 
-    static final int OTSCATTER   = 8; 
-    static final int OTCBIN      = 9;  // coordinate break input
-    static final int OTCBOUT     = 10; // coordinate break output
-    static final int OTBLFRONT   = 11; // bimodal lens front
-    static final int OTBLBACK    = 12; // bimodal lens back
-    static final int OTUNK       = 13; // unknown type; SNH.
+ // static final int OTSCATTER   = 8; 
+    static final int OTGSCATTER  = 8;  // A195  Gaussian scatter type
+    static final int OTUSCATTER  = 9;  // A195  Uniform scatter type
+    static final int OTCBIN      = 10; // coordinate break input
+    static final int OTCBOUT     = 11; // coordinate break output
+    static final int OTBMIRROR   = 12; // bimodal mirror
+    static final int OTBLFRONT   = 13; // bimodal lens front
+    static final int OTBLBACK    = 14; // bimodal lens back
+    static final int OTTERMINATE = 15; 
+    static final int OTUNK       = 16; // unknown type; SNH.
 
     // phantom is merely an OTLENS with equal indices.
+    // transmission grating is merely a groovy lens
+    // reflection grating is merely a groovy mirror
 
     static final String sTypes[] = {
     "   lens",   // 0
@@ -469,12 +609,15 @@ interface B4constants
     "lensArr",   // 5  /// should be lens + OSOLVER=OSARRAY???
     "mirrArr",   // 6  /// nope, see RT13.dIntercept().
     "irisArr",   // 7  /// This is correct. 
-    "scatter",   // 8
-    "cbInput",   // 9
-    "cbOutput",  // 10
-    "bilens_f",  // 11  bimodal lens front surface
-    "bilens_r",  // 12  bimodal lens rear surface
-    "unknown"};  // 11  SNH
+    "g scat ",   // 8
+    "u scat ",   // 9
+    "cbInput",   // 10
+    "cbOutput",  // 11
+    "bimirror",  // 12
+    "bilens_f",  // 13  bimodal lens front surface
+    "bilens_r",  // 14  bimodal lens rear surface
+    "terminate", // 15  bimodal terminator
+    "unknown"};  // 16  SNH
 
 /*-----------OPROFILE attributes and strings------------------*/
 
@@ -494,7 +637,8 @@ interface B4constants
     static final int OSZERNTOR = 13; 
     static final int OSBICONIC = 14;
     static final int OSARRAY   = 15;
-    static final int OSNFLAGS  = 16;   
+    static final int OSGAUSS   = 16;
+    static final int OSNFLAGS  = 17;   
 
     static final String[] sProfiles = {
     "Plano",     // 0 
@@ -512,7 +656,8 @@ interface B4constants
     "ZernRev",   // 12
     "ZernTor",   // 13
     "Biconic",   // 14
-    "Array"};    // 15   
+    "Array",     // 15
+    "****Gauss****"};    // 16 
 
 
 
@@ -532,7 +677,7 @@ interface B4constants
     static final int RSWAVEL        =     7; // raystarts[][] only
     static final int RSCOLOR        =     8; // raystarts[][] only
     static final int RSORDER        =     9; // raystarts[][] only
-    static final int RNSTARTS       =    10; // dimension of raystart[].
+    static final int RNSTARTS       =    10; // raystart[] attributes.
 
 /*-------------- ray output index local attribute macrodefs--------------*/
 
@@ -658,30 +803,31 @@ interface B4constants
 
 
 //-------User Option Group Macros--------------
-
-   static final int UO_IO      = 0; 
-   static final int UO_LAYOUT  = 1; 
-   static final int UO_AUTO    = 2; 
-   static final int UO_PLOT2   = 3; 
-   static final int UO_MPLOT   = 4;
-   static final int UO_MAP     = 5; 
-   static final int UO_PLOT3   = 6; 
-   static final int UO_1D      = 7; 
-   static final int UO_2D      = 8; 
-   static final int UO_RAND    = 9; 
-   static final int UO_CAD     = 10; 
-   static final int UO_START   = 11; 
-   static final int UO_EDIT    = 12;
-   static final int UO_GRAPH   = 13;
-   static final int UO_DEF     = 14; 
-   static final int UO_1DRAY   = 15; 
-   static final int UO_2DRRAY  = 16; 
-   static final int UO_2DCRAY  = 17; 
-   static final int UO_2DCGAUS = 18; 
-   static final int UO_RECENTO = 19; 
-   static final int UO_RECENTR = 20; 
-   static final int UO_RECENTM = 21; 
-   static final int NUOGROUPS  = 22; 
+   
+   static final int UO_NEWFILE = 0;  // skeleton options
+   static final int UO_IO      = 1; 
+   static final int UO_LAYOUT  = 2; 
+   static final int UO_AUTO    = 3;
+   static final int UO_PLOT2   = 4; 
+   static final int UO_MPLOT   = 5;
+   static final int UO_MAP     = 6; 
+   static final int UO_PLOT3   = 7; 
+   static final int UO_1D      = 8; 
+   static final int UO_2D      = 9; 
+   static final int UO_RAND    = 10; 
+   static final int UO_CAD     = 11; 
+   static final int UO_START   = 12; 
+   static final int UO_EDIT    = 13;
+   static final int UO_GRAPH   = 14;
+   static final int UO_DEF     = 15; 
+   static final int UO_1DRAY   = 16; 
+   static final int UO_2DRRAY  = 17; 
+   static final int UO_2DCRAY  = 18; 
+   static final int UO_2DCGAUS = 19; 
+   static final int UO_RECENTO = 20; 
+   static final int UO_RECENTR = 21; 
+   static final int UO_RECENTM = 22; 
+   static final int NUOGROUPS  = 23; 
 
 //--------UO strings: avoid "|" used in parsing-----------
 //----UO strings is a ragged right array, 
@@ -689,7 +835,13 @@ interface B4constants
 
    static final String UO[][][] = 
    {
-       {  // group 0 = UO_IO
+       {  // group 0 = UO_NEWFILE
+          {"Nrecords",             "15"},   // 0; nrows = Nrecords + 3
+          {"Nfields",              "10"},   // 1
+          {"FieldWidth",           "18"}    // 2
+       },
+         
+       {  // group 1 = UO_IO
           {"Show RMS when goals exist", "T"}
        },
 
@@ -732,7 +884,9 @@ interface B4constants
           {"Sticky uyspan",           "0"},  // 35
           {"Sticky uzspan",           "0"},  // 36
           {"Refractor connectors?",   "F"},  // 37
-          {"Retro visible?",          "T"}   // 38
+          {"Retro visible?",          "T"},  // 38
+          {"Dotted extension %",      "4"}   // 39
+          
        },
 
        {  // group 2 = UO_AUTO
@@ -757,10 +911,10 @@ interface B4constants
           {"Plus",                            "F"},  // 6
           {"Square",                          "F"},  // 7
           {"Diamond",                         "F"},  // 8
-          {"Good rays",                       "T"},  // 9   plot good rays
-          {"All rays",                        "F"},  // 10  plot all rays
-          {"Additional surface, none if zero", ""},  // 11
-          {"Black Background",                "F"}   // 12
+          {"Complete rays",                   "T"},  // 9  RROK
+          {"Sufficient rays",                 "F"},  // 10 enough surfs
+          // {"Additional surface, none if zero", ""},  // elim A207
+          {"Black Background",                "F"}   // 11
        },
 
        {  // group 4 = UO_MPLOT  MultiPlot options
@@ -843,8 +997,8 @@ interface B4constants
           {"Plus",           "F"},   // 10
           {"Sqr",            "F"},   // 11
           {"Diam",           "F"},   // 12
-          {"Good rays",      "T"},   // 13
-          {"All rays",       "F"},   // 14
+          {"Complete rays",  "T"},   // 13
+          {"Sufficient rays","F"},   // 14
           {"White",          "T"},   // 15
           {"Black",          "F"},   // 16
           {"Stereo",         "F"},   // 17
@@ -1074,7 +1228,6 @@ interface B4constants
           {"RM8", ""},
           {"RM9", ""}
        }   
-    };
-
-} //--------end of Constants.java---------------------
+    };    
+} //--------end of B4onstants.java---------------------
 

--- a/Sources/Comparo.java
+++ b/Sources/Comparo.java
@@ -27,7 +27,7 @@ class Comparo implements B4constants
     
     private static OEJIF optEditor = null; 
     private static REJIF rayEditor = null; 
-    private static int ngroups=0, nrays=0, onfields=0, rnfields=0;
+    private static int nrays=0, nsurfs=0, onfields=0, rnfields=0;
     private static int ngood=0, ngoals=0, nadj=0; 
     private static int npts=0; 
     private static double sos=0.0;
@@ -62,7 +62,7 @@ class Comparo implements B4constants
         {
             for (int kray=1; kray<=nrays; kray++)
             {
-                if (RT13.bGoodRay[kray])
+                if (RT13.isRayOK[kray])
                   for (int igoal=0; igoal<ngoals; igoal++)
                   {
                       double t1 = getRay(kray, goalAttrib[igoal]); 
@@ -77,7 +77,7 @@ class Comparo implements B4constants
         if (bHasWFE)  // implicit goal case
         {
             for (int kray=1; kray<=nrays; kray++)
-              if (RT13.bGoodRay[kray])
+              if (RT13.isRayOK[kray])
               {
                   resid[npts] = getRay(kray, RTWFE);
                   sos += resid[npts]*resid[npts]; 
@@ -109,9 +109,9 @@ class Comparo implements B4constants
     {
         optEditor = DMF.oejif;
         rayEditor = DMF.rejif;
-        ngroups   = DMF.giFlags[ONGROUPS]; 
         onfields  = DMF.giFlags[ONFIELDS];       // fields per optic.
         nrays     = DMF.giFlags[RNRAYS]; 
+        nsurfs    = DMF.giFlags[ONSURFS]; 
         rnfields  = DMF.giFlags[RNFIELDS];       // fields per ray.
         ngoals    = DMF.giFlags[RNGOALS];        // verified above. 
         bHasWFE   = DMF.giFlags[RWFEFIELD] > RABSENT; 
@@ -119,7 +119,7 @@ class Comparo implements B4constants
         if ((optEditor==null) || (rayEditor==null))
           return false; // SNH graying.
 
-        if ((ngroups<1) || (onfields<1) || (nrays<1) || (rnfields<1))
+        if ((onfields<1) || (nrays<1) || (rnfields<1))
           return false; // SNH graying. 
 
         if ((ngoals < 1) && !bHasWFE)
@@ -164,11 +164,11 @@ class Comparo implements B4constants
 
 
 
-    private static double getRay(int kray, int iattrib)
+    private static double getRay(int kray, int iattrib)  // at final surface
     {
         if ((iattrib>=RX) && (iattrib<RNATTRIBS))
         {
-            double d = RT13.dGetRay(kray, ngroups, iattrib);
+            double d = RT13.dGetRay(kray, nsurfs, iattrib); 
             return d; 
         }
         return -0.0;
@@ -187,7 +187,7 @@ class Comparo implements B4constants
         {
             int f = goalField[igoal]; 
             for (int kray=1; kray<=nrays; kray++)
-              bLookedAt[kray] = !RT13.bGoodRay[kray];  
+              bLookedAt[kray] = !RT13.isRayOK[kray];  
 
             for (int ktop=1; ktop<=nrays; ktop++) // search for top ray this tag
             {
@@ -207,7 +207,7 @@ class Comparo implements B4constants
                 double value = 0.0; // average will include ktop itself. 
                 for (int k=ktop; k<=nrays; k++)
                 {
-                    if (RT13.bGoodRay[k] 
+                    if (RT13.isRayOK[k] 
                     && !bLookedAt[k] 
                     && (tag==rayEditor.getTag(f,k+2)))
                     {

--- a/Sources/EJIF.java
+++ b/Sources/EJIF.java
@@ -676,7 +676,11 @@ abstract class EJIF extends BJIF implements B4constants, AdjustmentListener
     {
         if (ePanel == null)
           return; 
-        ePanel.putFieldDouble(f, r, d); 
+        // blanking negative zeros introduced 26 Dec 2018 A207
+        if (U.isNegZero(d))
+            putBlank(f,r);
+        else  
+            ePanel.putFieldDouble(f, r, d); 
         bDirty = true; 
         // bNeedsParse = true; // not here this is calculation driven
     }

--- a/Sources/H2DPanel.java
+++ b/Sources/H2DPanel.java
@@ -8,7 +8,7 @@ import java.io.*;          // Save Data
 /**
   * H2DPanel extends GPanel, draws 2D binned ray histogram.
   * Random ray responder is installed.
-  *
+  * A207: eliminates groups
   * 
   * Because the x, y, and z scaling factors are different,
   * integer bins & counts are scaled to a unit cube for display.
@@ -79,7 +79,6 @@ public class H2DPanel extends GPanel
     // Called by GPanel for artwork: new, pan, zoom, & random ray group.
     {
         nsurfs = DMF.giFlags[ONSURFS];                 // always needed.
-        ngroups = DMF.giFlags[ONGROUPS];               // always needed.
         nrays = DMF.giFlags[RNRAYS];                   // always needed.
         ngood = RT13.iBuildRays(true);
                 
@@ -89,15 +88,7 @@ public class H2DPanel extends GPanel
         if (warn.length() > 0)
           return; 
 
-        //---see if group assignments have changed----
-        boolean bChanged = false; 
-        for (int j=0; j<MAXSURFS; j++)
-          if (prevGroups[j] != RT13.group[j])
-          {
-              prevGroups[j] = RT13.group[j]; 
-              bChanged = true; 
-          }
-        if ((npSurfs != nsurfs) || (npRays != nrays) || bPleaseParseUO || bChanged)
+        if ((npSurfs != nsurfs) || (npRays != nrays) || bPleaseParseUO)
         {
             doParse();     
             npSurfs = nsurfs; 
@@ -195,17 +186,16 @@ public class H2DPanel extends GPanel
     // Local variables shadow H2D fields.
     // First line of defense, must never crash. 
     {
-        ngroups = DMF.giFlags[ONGROUPS]; 
         String hst = DMF.reg.getuo(UO_2D, 2); 
         int hop = REJIF.getCombinedRayFieldOp(hst); 
-        int hsurf = RT13.getGroupNum(hop); 
+        int hsurf = RT13.getSurfNum(hop); 
         int hattr = RT13.getAttrNum(hop); 
         if ((hsurf<0) || (hattr<0) || (hattr>RNATTRIBS))
           return "H var unknown:  "+hst; 
 
         String vst = DMF.reg.getuo(UO_2D, 3); 
         int vop = REJIF.getCombinedRayFieldOp(vst); 
-        int vsurf = RT13.getGroupNum(vop); 
+        int vsurf = RT13.getSurfNum(vop); 
          int vattr = RT13.getAttrNum(vop); 
         if ((vsurf<0) || (vattr<0) || (vattr>RNATTRIBS))
           return "V var unknown:  "+vst; 
@@ -225,12 +215,12 @@ public class H2DPanel extends GPanel
 
         hst = DMF.reg.getuo(UO_2D, 2); 
         int hop = REJIF.getCombinedRayFieldOp(hst); 
-        hsurf = RT13.getGroupNum(hop); 
+        hsurf = RT13.getSurfNum(hop); 
         hattr = RT13.getAttrNum(hop); 
 
         vst = DMF.reg.getuo(UO_2D, 3); 
         int vop = REJIF.getCombinedRayFieldOp(vst); 
-        vsurf = RT13.getGroupNum(vop); 
+        vsurf = RT13.getSurfNum(vop); 
         vattr = RT13.getAttrNum(vop); 
 
         nhbins = U.parseInt(DMF.reg.getuo(UO_2D, 4));  
@@ -260,7 +250,7 @@ public class H2DPanel extends GPanel
         RT13.iBuildRays(true); 
         for (int kray=1; kray<=nrays; kray++)
         {
-            if (RT13.bGoodRay[kray])
+            if (RT13.isRayOK[kray])
             {
                 double h = RT13.dGetRay(kray, hsurf, hattr); 
                 double v = RT13.dGetRay(kray, vsurf, vattr); 
@@ -387,7 +377,7 @@ public class H2DPanel extends GPanel
           for (int j=0; j<nvbins; j++)
             histo[i][j] = 0; 
         for (int kray=1; kray<=nrays; kray++)
-          if (RT13.bGoodRay[kray])
+          if (RT13.isRayOK[kray])
             addRayToHisto(kray); 
 
         //  ...and get histopeak and dhisto[][]
@@ -435,7 +425,7 @@ public class H2DPanel extends GPanel
 
     private void doArt()
     {
-        ngroups = DMF.giFlags[ONGROUPS];
+        nsurfs = DMF.giFlags[ONSURFS];
         nrays = DMF.giFlags[RNRAYS];
         double xyz[] = new double[3]; 
 

--- a/Sources/MEJIF.java
+++ b/Sources/MEJIF.java
@@ -63,7 +63,7 @@ class MEJIF extends EJIF
         if (nglasses < 1)
           return; 
 
-        /////////////// initialize the nongeneric output data //////////////
+        /////////////// initialize the output data //////////////
 
         DMF.giFlags[MNWAVES] = 0;
         DMF.giFlags[MSYNTAXERR] = 0; 
@@ -80,15 +80,21 @@ class MEJIF extends EJIF
 
         //////////// mwaves[1...] begin at field=1, line=1 //////
 
-        for (int f=1; f<nfields; f++)  // skip field zero
-          mwaves[f] = getFieldTrim(f, 1); 
+        for (int f=1; f<nfields; f++)  // skip field zero it is not a wavelength field
+        {
+             mwaves[f] = getFieldTrim(f, 1); 
+             // System.out.println("MEJIF finds wave name = "+mwaves[f]);
+        }
         DMF.giFlags[MNWAVES] = nfields-1; 
 
 
         //////// mglasses[1...]  begin at record=1, line=3 /////
 
         for (int irec=1; irec<=DMF.giFlags[MNGLASSES]; irec++)
-          mglasses[irec] = getFieldTrim(0, irec+2); 
+        {
+            mglasses[irec] = getFieldTrim(0, irec+2); 
+            // System.out.println("MEJIF finds glass name = "+mglasses[irec]);
+        } 
 
         //////// parse the data records into RT13.media[][] //////
 
@@ -97,7 +103,8 @@ class MEJIF extends EJIF
         {
             for (int irec=1; irec<=DMF.giFlags[MNGLASSES]; irec++)
             {
-                RT13.media[irec][f] = getFieldDouble(f, 2+irec); 
+                double n = RT13.media[irec][f] = getFieldDouble(f, 2+irec); 
+                // System.out.printf("MEJIF refraction at f,g= %3d %3d %8.5f \n", f, irec, n);
                 if (Double.isNaN(RT13.media[irec][f])) 
                 {
                     badline = irec+2; 
@@ -113,6 +120,8 @@ class MEJIF extends EJIF
               break; 
         }
         DMF.giFlags[MSYNTAXERR] = msyntaxerr; 
+        // System.out.println("MEJIF finds nwaves = " + DMF.giFlags[MNWAVES]);
+        // System.out.println("MEJIF finds nglasses = " + DMF.giFlags[MNGLASSES]); 
     } // end of parse(). 
 }
 

--- a/Sources/MPlotPanel.java
+++ b/Sources/MPlotPanel.java
@@ -6,7 +6,7 @@ import java.util.*;        // ArrayList
 @SuppressWarnings("serial")
 
 /** MultiPlot Artwork Generator
-  *
+  * A207: eliminating groups
   * A173: Adopting five GPanel quadLists and GPanel helper methods.
   *
   * A150: uses new Options dialog with explicit lists of variable values;
@@ -158,7 +158,6 @@ public class MPlotPanel extends GPanel
     // for annotation, host's bitmap is blitted instead.
     {    
         nsurfs    = DMF.giFlags[ONSURFS];    // input stuff
-        ngroups   = DMF.giFlags[ONGROUPS]; 
         nrays     = DMF.giFlags[RNRAYS]; 
         kcolor    = new int[MAXMP][MAXMP][MAXRAYS];  
         steps     = new double[MAXMP][MAXMP][2]; 
@@ -266,7 +265,6 @@ public class MPlotPanel extends GPanel
     //
     {
         nsurfs = DMF.giFlags[ONSURFS];  
-        ngroups = DMF.giFlags[ONGROUPS]; 
         nrays = DMF.giFlags[RNRAYS]; 
 
         for (int ix=0; ix<MAXMP; ix++)
@@ -615,7 +613,6 @@ public class MPlotPanel extends GPanel
     // Warning: this routine sets RT13.gwave to commandeer wavelengths.
     // When done be sure to reset RT13.gwave=0 to restore kray control. 
     {
-        ngroups = DMF.giFlags[ONGROUPS]; 
         nrays = DMF.giFlags[RNRAYS]; 
         
         setTempParms(ix, iy);

--- a/Sources/MapPanel.java
+++ b/Sources/MapPanel.java
@@ -8,7 +8,8 @@ import java.awt.event.*;   // Events
 
 @SuppressWarnings("serial")
 
-/** March 2015: adopted explicit QBASE for artwork quads. 
+/** Dec 2018 A207 eliminating groups (yay!)
+  * March 2015: adopted explicit QBASE for artwork quads. 
   * March 2015: improved output text file, including .CSV format.
   * 2012: Scales added for HorVar and VertVar
   * 2011: With this plan every options starts a fresh new run.
@@ -178,7 +179,6 @@ public class MapPanel extends GPanel // implements Runnable
     // Do not request repaint() here: this is a provider not a requestor. 
     {
         nsurfs = DMF.giFlags[ONSURFS]; 
-        ngroups = DMF.giFlags[ONGROUPS];
         nrays = DMF.giFlags[RNRAYS];  
         
         if (bPleaseParseUO)
@@ -241,7 +241,6 @@ public class MapPanel extends GPanel // implements Runnable
     // First line of defense! must never crash. 
     {
         nsurfs = DMF.giFlags[ONSURFS]; 
-        ngroups = DMF.giFlags[ONGROUPS]; 
         nrays = DMF.giFlags[RNRAYS]; 
         if (nsurfs<1) 
           return "No surfaces are defined"; 
@@ -290,10 +289,10 @@ public class MapPanel extends GPanel // implements Runnable
 
         //----test the map parameters for validity----
         
-        boolean ok = parseOneStepVar(sHvar, asH, ngroups); 
+        boolean ok = parseOneStepVar(sHvar, asH, nsurfs); 
         if (!ok)
           return "Hvar unknown"; 
-        ok = parseOneStepVar(sVvar, asV, ngroups); 
+        ok = parseOneStepVar(sVvar, asV, nsurfs); 
         if (!ok)
           return "Vvar unknown"; 
         
@@ -308,13 +307,13 @@ public class MapPanel extends GPanel // implements Runnable
         
         if (sHpar.length() > 0)
         {
-            ok = parseOneStepVar(sHpar, asHp, ngroups); 
+            ok = parseOneStepVar(sHpar, asHp, nsurfs); 
             if (!ok)
               return "Hparallax is unknown";
         }
         if (sVpar.length() > 0)
         {
-            ok = parseOneStepVar(sVpar, asVp, ngroups); 
+            ok = parseOneStepVar(sVpar, asVp, nsurfs); 
             if (!ok)
               return "Vparallax is unknown"; 
         }
@@ -435,7 +434,7 @@ public class MapPanel extends GPanel // implements Runnable
     {
         if (jsurf > nsurfs)
           return -0.0; 
-        return RT13.dGetSurf(iatt, jsurf); 
+        return RT13.dGetSurfParm(iatt, jsurf); 
     }
 
 
@@ -510,9 +509,9 @@ public class MapPanel extends GPanel // implements Runnable
         //---trace the rays and gather the datum for this box--------
         //---Note: REJIF line 88 sets each ray WFE group index=0
         //---prior to running a trace for WFE evaluation. 
-            
-        for (int kray=0; kray<=nrays; kray++)
-          RT13.iWFEgroup[kray] = 0;   // all rays are in WFEgroup zero
+        // A207 eliminated WFEs    
+        // for (int kray=0; kray<=nrays; kray++)
+        //   RT13.iWFEgroup[kray] = 0;   // all rays are in WFEgroup zero
         
         double d = -0.0; 
         int ngood = RT13.iBuildRays(true);  // builds all rays
@@ -638,8 +637,8 @@ public class MapPanel extends GPanel // implements Runnable
         // RFINAL in B4Constants = 10000; placeholder for 100*nsurfs term.
         int opxf  = RFINAL + RTXL;  // opcode for xfinal
         int opyf  = RFINAL + RTYL;  // opcode for yfinal
-        int xsurf = RT13.getGroupNum(opxf); // handles "final" surface 
-        int ysurf = RT13.getGroupNum(opyf); // handles "final" surface
+        int xsurf = RT13.getSurfNum(opxf); // handles "final" surface 
+        int ysurf = RT13.getSurfNum(opyf); // handles "final" surface
         if ((xsurf < 1) || (ysurf < 1))
           return BADCELL; 
         int n = 0; 

--- a/Sources/OEJIF.java
+++ b/Sources/OEJIF.java
@@ -790,6 +790,8 @@ class OEJIF extends EJIF
                       return OODIAX;
                     if (s.contains("Y"))
                       return OODIAY;
+                    if (s.contains("P"))
+                      return ODIOP;
                     return OODIAM;
                     
           case 'd': if (s.contains("X"))
@@ -799,11 +801,7 @@ class OEJIF extends EJIF
                     return OIDIAM;       
           
           case 'F':
-          case 'f': switch(c2up)
-                    {
-                      case 'C': return OFOCAL; // focal length for thin perfect lenses
-                      default: return OFORM;  // "form" = nonnumerical
-                    }
+          case 'f': return OFORM;  // "form" = nonnumerical
 
           case 'G':
           case 'g': switch(c1up)   // Group or Grating groove density

--- a/Sources/OEJIF.java
+++ b/Sources/OEJIF.java
@@ -172,6 +172,8 @@ class OEJIF extends EJIF
                                break; 
                            }
                            break;
+                 case 't':
+                 case 'T': RT13.surfs[jsurf][OTYPE] = OTTHIN;
                  default: RT13.surfs[jsurf][OTYPE] = OTLENS; break; 
                }
                typetag[jsurf] = getTag(ifield, 2+jsurf); 
@@ -802,7 +804,11 @@ class OEJIF extends EJIF
                     return OIDIAM;       
           
           case 'F':
-          case 'f': return OFORM;  // "form" = nonnumerical
+          case 'f': switch(c2up)
+                    {
+                      case 'c': return OFOCAL; // focal length for thin perfect lenses
+                      default: return OFORM;  // "form" = nonnumerical
+                    }
 
           case 'G':
           case 'g': switch(c1up)   // Group or Grating groove density

--- a/Sources/OEJIF.java
+++ b/Sources/OEJIF.java
@@ -173,7 +173,7 @@ class OEJIF extends EJIF
                            }
                            break;
                  case 't':
-                 case 'T': RT13.surfs[jsurf][OTYPE] = OTTHIN;
+                 case 'T': RT13.surfs[jsurf][OTYPE] = OTTHIN; break;
                  default: RT13.surfs[jsurf][OTYPE] = OTLENS; break; 
                }
                typetag[jsurf] = getTag(ifield, 2+jsurf); 

--- a/Sources/OEJIF.java
+++ b/Sources/OEJIF.java
@@ -806,7 +806,7 @@ class OEJIF extends EJIF
           case 'F':
           case 'f': switch(c2up)
                     {
-                      case 'c': return OFOCAL; // focal length for thin perfect lenses
+                      case 'C': return OFOCAL; // focal length for thin perfect lenses
                       default: return OFORM;  // "form" = nonnumerical
                     }
 

--- a/Sources/OEJIF.java
+++ b/Sources/OEJIF.java
@@ -12,6 +12,7 @@ import javax.swing.text.*;  // BadLocationException
   *  The function of parse() is to set values into DMF.giFlags[] and RT13.surfs[][]. 
   *
   *  It implements Constants via EJIF. 
+  *  The ACTUAL PARSING WORK is done by getOptFieldAttrib(String s), bottom of this file.
   *
   *  parse() has no dirty bit worksavers; it always parses. 
   *
@@ -48,7 +49,6 @@ class OEJIF extends EJIF
         DMF.giFlags[OPRESENT] = status[GPRESENT]; 
         DMF.giFlags[ONLINES]  = status[GNLINES]; 
         DMF.giFlags[ONSURFS]  = nsurfs = status[GNRECORDS]; 
-        DMF.giFlags[ONGROUPS] = nsurfs; 
         DMF.giFlags[ONFIELDS] = nfields = status[GNFIELDS]; 
         if (nsurfs < 1)
           return; 
@@ -64,9 +64,6 @@ class OEJIF extends EJIF
               RT13.surfs[j][ia] = -0.0; // minus zero means blank entry.
               
             RT13.surfs[j][OREFRACT] = 1.0; 
-            RT13.jstart[j] = j;  // groups
-            RT13.jstop[j]  = j;  // groups
-            RT13.group[j]  = j;  // groups
         }
  
         for (int f=0; f<MAXFIELDS; f++)
@@ -110,9 +107,6 @@ class OEJIF extends EJIF
         for (int jsurf=1; jsurf<=nsurfs; jsurf++)
         {
             RT13.surfs[jsurf][OTYPE] = OTLENS;  // default
-            RT13.jstart[jsurf] = jsurf;         // default
-            RT13.jstop[jsurf]  = jsurf;         // default
-            RT13.group[jsurf]  = jsurf;         // default
         }
           
         //-----first parse the optics type column---------
@@ -127,15 +121,36 @@ class OEJIF extends EJIF
               char c4 = U.getCharAt(s.toUpperCase(), 4); 
               switch(c0)
               {
-                 case 'b': // bimodal lens front="bif" else back "bix".
-                 case 'B': RT13.surfs[jsurf][OTYPE]
-                            = (c2=='F') ? OTBLFRONT : OTBLBACK; break; 
-                            
+                 case 'b': // bimodal lens front="bif" "bir" "bib" "bim"
+                 case 'B': if (c2 == 'F')
+                               RT13.surfs[jsurf][OTYPE]  = OTBLFRONT;
+                            if ((c2 == 'R') || (c2 == 'B'))
+                               RT13.surfs[jsurf][OTYPE] = OTBLBACK;
+                            if (c2 == 'M')
+                               RT13.surfs[jsurf][OTYPE] = OTBMIRROR;
+                            if (c2 == 'T')
+                               RT13.surfs[jsurf][OTYPE] = OTTERMINATE;    
+                            break; 
+
+                 case 'c':     // coordinate breaks
+                 case 'C': if (c2 == 'I')
+                           {
+                               RT13.surfs[jsurf][OTYPE] = OTCBIN; 
+                               break;
+                           }
+                           if (c2 == 'O')
+                           {
+                               RT13.surfs[jsurf][OTYPE] = OTCBOUT; 
+                               break; 
+                           }
+                           break;
+                           
                  case 'i': // iris
                  case 'I': RT13.surfs[jsurf][OTYPE] 
                              = (c4=='A') ? OTIRISARRAY : OTIRIS; break; 
 
-                 case 'G': RT13.surfs[jsurf][OTYPE] = OTMIRROR; break;
+                 case 'G': RT13.surfs[jsurf][OTYPE] 
+                             = (c2=='C') ? OTGSCATTER : OTMIRROR; break;  // A195
 
                  case 'l':
                  case 'L': RT13.surfs[jsurf][OTYPE] 
@@ -153,25 +168,20 @@ class OEJIF extends EJIF
                  // case 's':  // spider: replaced by iris with legs. 
 
                  case 's':
-                 case 'S':  RT13.surfs[jsurf][OTYPE] = OTSCATTER; break; 
+                 case 'S':  RT13.surfs[jsurf][OTYPE] = OTGSCATTER; break;  // A195 Gaussian scatter
+                 
+                 case 't':
+                 case 'T':  RT13.surfs[jsurf][OTYPE] = OTTERMINATE; break;  // Term is alternate to BiTerm
+                 
+                 case 'u':
+                 case 'U':  RT13.surfs[jsurf][OTYPE] = OTUSCATTER; break;  // A195 uniform scatter
  
                  case 'd':     // optical path distorters
                  case 'D':
                  case 'w':
                  case 'W': RT13.surfs[jsurf][OTYPE] = OTDISTORT; break; 
              
-                 case 'c':     // coordinate breaks
-                 case 'C': if (c2 == 'I')
-                           {
-                               RT13.surfs[jsurf][OTYPE] = OTCBIN; 
-                               break;
-                           }
-                           if (c2 == 'O')
-                           {
-                               RT13.surfs[jsurf][OTYPE] = OTCBOUT; 
-                               break; 
-                           }
-                           break;
+
                  default: RT13.surfs[jsurf][OTYPE] = OTLENS; break; 
                }
                typetag[jsurf] = getTag(ifield, 2+jsurf); 
@@ -201,38 +211,6 @@ class OEJIF extends EJIF
           } 
           
           
-        //-----parse the groups if group column is present-----
-        
-        ifield = oI2F[OGROUP];  
-        char cGroup[] = new char[MAXSURFS+1]; 
-        for (int j=1; j<=MAXSURFS; j++)
-          cGroup[j] = ' ';
-        if (ifield > ABSENT)   // groups column present?
-        {
-            for (int j=1; j<=nsurfs; j++)
-              cGroup[j] = U.getCharAt(getFieldTrim(ifield, 2+j), 0); 
-            RT13.group[1]  = 1; 
-            RT13.jstart[1] = 1;
-            RT13.jstop[1]  = 1; 
-
-            for ( int j=1; j<=MAXSURFS; j++)
-            {
-                boolean bNew = (cGroup[j] == ' ') 
-                            || (cGroup[j-1] == ' ')
-                            || (cGroup[j] != cGroup[j-1]); 
-                int g = bNew ? RT13.group[j-1]+1 : RT13.group[j-1];           
-                RT13.group[j]  = g; 
-                if (bNew)         
-                  RT13.jstart[g] = j;
-                RT13.jstop[g]  = j;    
-            }
-            for (int j=nsurfs+1; j<=MAXSURFS; j++)
-               RT13.group[j] = RT13.group[nsurfs]; 
-
-            DMF.giFlags[ONGROUPS] = RT13.group[nsurfs]; 
-        }
-              
-      
         //----------refraction: sometimes numerical data--------------
         //---if refraction LUT is needed, OREFRACT will be NaN.----
 
@@ -266,6 +244,7 @@ class OEJIF extends EJIF
             for (int f=0; f<nfields; f++)
             {
                 int ia = oF2I[f];   // attribute of this surface
+
                 if (ia == OTYPE)    // types were analyzed above...
                   continue; 
                 if (ia == OFORM)    // forms were analyzed above...
@@ -387,8 +366,8 @@ class OEJIF extends EJIF
         for (int j=1; j<=nsurfs; j++)
         {
             boolean bGroovy = false; 
-            for (int kg=OGX; kg<=OHOELAM; kg++)
-              if (Math.abs(RT13.surfs[j][kg])>0.0)
+            for (int kg=OORDER; kg<OGROOVY; kg++)
+              if (RT13.surfs[j][kg] != 0.0)
                 bGroovy = true;
             RT13.surfs[j][OGROOVY] = bGroovy ? 1.0 : 0.0; 
         }
@@ -516,7 +495,11 @@ class OEJIF extends EJIF
 
             if (bZern)
               iProfile = (iProfile==OSTORIC) ? OSZERNTOR : OSZERNREV;
-
+              
+            if (RT13.surfs[j][ORGAUSS] > 0.)  // found a Gaussian surface profile
+            {
+                iProfile = OSGAUSS; 
+            }
             //---------apply hints to conic or cyl, not higher----------
 
             switch (iProfile)
@@ -534,6 +517,8 @@ class OEJIF extends EJIF
                   if ('>' == typetag[j])  iProfile = OSYCYLGT;
                   break; 
             }
+            // System.out.println("OEJIF parse() surface= "+j+" finds iProfile= "+iProfile+"  "+sProfiles[iProfile]); 
+            
             RT13.surfs[j][OPROFILE] = iProfile; 
         }
 
@@ -542,14 +527,12 @@ class OEJIF extends EJIF
         dOsize = 0.0; 
         for (int j=1; j<=nsurfs; j++)
         {
-           dOsize += Math.abs(RT13.surfs[j][OX]); 
-           dOsize += Math.abs(RT13.surfs[j][OY]); 
-           dOsize += Math.abs(RT13.surfs[j][OZ]); 
-           dOsize += Math.abs(RT13.surfs[j][OODIAM]); 
-           dOsize += Math.abs(RT13.surfs[j][OODIAX]); 
+           dOsize = Math.max(dOsize, Math.abs(RT13.surfs[j][OX])); 
+           dOsize = Math.max(dOsize, Math.abs(RT13.surfs[j][OY])); 
+           dOsize = Math.max(dOsize, Math.abs(RT13.surfs[j][OZ])); 
+           dOsize = Math.max(dOsize, Math.abs(RT13.surfs[j][OODIAM])); 
+           dOsize = Math.max(dOsize, Math.abs(RT13.surfs[j][OODIAX])); 
         }
-        if (nsurfs > 1)
-          dOsize /= nsurfs; 
         if (dOsize < TOL)
           dOsize = 1.0;
           
@@ -732,13 +715,19 @@ class OEJIF extends EJIF
     // Table data should be numerical, except ABSENT, OFORM, OTYPE, OREFRACT. 
     // Radius of curvature is written "RxCxxxx" i.e. c2up='C'.
     {
-        char c0=' ', c1up=' ', c2up=' ', c3up=' ', c4up=' ';
+        // System.out.println("OEJIF method getOptFieldAttrib() is given arg = "+s); 
+        char c0=' ', c0up=' ', c1up=' ', c2up=' ', c3up=' ', c4up=' ';
+        String svls = ""; 
+        
         s = s.trim(); 
         int len = s.length(); 
         if (len < 1)
           return ABSENT;
-        c0 = s.charAt(0); 
-        s = s.toUpperCase(); 
+        c0 = s.charAt(0);                  // save case of c0
+        c0up = Character.toUpperCase(c0); 
+        if ((len == 4) && (c0up == 'V'))
+          svls = s.toUpperCase(); 
+        s = s.toUpperCase();               // ignore case beyond c0
         if (len > 1)
           c1up = s.charAt(1); 
         if (len > 2)
@@ -776,9 +765,9 @@ class OEJIF extends EJIF
                        case '9': return OA9;
                        case 'C': return OTYPE; // "ACTION"
                     }
-                    if (s.contains("X"))
+                    if (s.endsWith("X"))
                       return OASPHX;
-                    if (s.contains("Y"))
+                    if (s.endsWith("Y") && (len < 9)) // allows 'asphericity'
                       return OASPHY;
                     return OASPHER;
 
@@ -810,17 +799,20 @@ class OEJIF extends EJIF
                        case 'R': return OGROUP;
                        case 'X': return OGX;
                        case 'Y': return OGY;
-                       case '1': return OVLS1;
-                       case '2': return OVLS2;
-                       case '3': return OVLS3;
-                       case '4': return OVLS4;
+                       // case '1': return OVLS1;    // removed 22 March 2016 A192
+                       // case '2': return OVLS2;
+                       // case '3': return OVLS3;
+                       // case '4': return OVLS4;
                     }
                     return ABSENT;
 
           case 'H':
-          case 'h': if (len < 4)     // HOE entries
-                  return ABSENT;
-                switch(c3up)
+          case 'h': if (len < 4)    
+                return ABSENT;
+                if (c1up=='G') 
+                   return OHGAUSS;  // height of 2D Gaussian
+                  
+                switch(c3up)         // HOE entries
                 {
                     case 'L':
                     case 'l': return OHOELAM;
@@ -873,29 +865,85 @@ class OEJIF extends EJIF
           case 'p':  return OPITCH;
 
           case 'R':
-          case 'r':  if ((c2up=='C') && (c3up=='X')) return ORADX;
+          case 'r':  if (c1up=='G') return ORGAUSS;   // 2D Gaussian radius or sigma          
+                     if ((c2up=='C') && (c3up=='X')) return ORADX;
                      if ((c2up=='C') && (c3up=='Y')) return ORADY;
                      if (c2up=='C') return ORAD;  
                      return OROLL;
 
           case 'S':
-          case 's':  if (c1up=='C')  return OSCATTER; 
+          case 's':  if (c1up=='C')  return OSCATTER;  // angle, degrees 
                      return OSHAPE; 
 
           case 'T':
           case 't':  if (c1up == 'Y')  return OTYPE; 
                      return OTILT;     // tilt. 
 
-          case 'V':
-          case 'v':  switch (c3up)
+          case 'V':   // twenty curl-free explicit VLS coefficients
+          case 'v':  
+                     if (svls.equals("VX00")) return OGX;    // synonym
+                     if (svls.equals("VX10")) return OVX10; 
+                     if (svls.equals("VX20")) return OVX20; 
+                     if (svls.equals("VX30")) return OVX30;
+                     if (svls.equals("VX40")) return OVX40; 
+                     if (svls.equals("VY00")) return OGY;    // synonym
+                     if (svls.equals("VY01")) return OVY01; 
+                     if (svls.equals("VY02")) return OVY02; 
+                     if (svls.equals("VY03")) return OVY03;
+                     if (svls.equals("VY04")) return OVY04; 
+                     if (svls.equals("VY10")) return OVY10;
+                     if (svls.equals("VY11")) return OVY11;
+                     if (svls.equals("VY12")) return OVY12;
+                     if (svls.equals("VY13")) return OVY13; 
+                     if (svls.equals("VY20")) return OVY20;
+                     if (svls.equals("VY21")) return OVY21;
+                     if (svls.equals("VY22")) return OVY22; 
+                     if (svls.equals("VY30")) return OVY30; 
+                     if (svls.equals("VY31")) return OVY31; 
+                     if (svls.equals("VY40")) return OVY40; 
+                     return ABSENT;
+          
+          
+                    /***************************************
+                    switch (c1up)
                      {
-                        case '1': return OVLS1;
-                        case '2': return OVLS2;
-                        case '3': return OVLS3;
-                        case '4': return OVLS4;
+                        case 'X': switch(c2up)
+                                  {
+                                     case '1': return OVLX10;
+                                     case '2': return OVLX20;
+                                     case '3': return OVLX30;
+                                     default: return ABSENT;
+                                  }                        
+                        case 'Y': switch (c2up)
+                                  {
+                                    case '0':  switch(c3up)
+                                               {
+                                                   case '1': return OVLY01; 
+                                                   case '2': return OVLY02;
+                                                   case '3': return OVLY03;
+                                                   default: return ABSENT;
+                                                }
+                                    case '1': switch(c3up)
+                                              {
+                                                  case '0': return OVLY10;
+                                                  case '1': return OVLY11; 
+                                                  case '2': return OVLY12; 
+                                                  default: return ABSENT;
+                                              } 
+                                     case '2': switch (c3up)
+                                               {
+                                                   case '0': return OVLY20;
+                                                   case '1': return OVLY21;
+                                                   default: return ABSENT;
+                                                }
+                                     case '3': if (c3up == '0') return OVLY30;
+                                  }
                      }
                      return ABSENT;
-
+                     ********************************/
+                     
+                     
+                     
           case 'W':
           case 'w':  if (c1up=='S')  
                        return OWSPIDER;

--- a/Sources/Options.java
+++ b/Sources/Options.java
@@ -15,7 +15,7 @@ import java.util.*;          // StringTokenizer
   *  
   *  Options extends JMenu, provides an options system using strings.
   *
-  *  ALL OPTION STRINGS ARE DEFINED IN CONSTANTS.JAVA not here. 
+  *  ALL OPTION STRINGS ARE DEFINED IN B4constants.java  not here. 
   *
   *  ActionListeners implement the dialogs to help separate GUI from code.
   *  Both Registry and Options implement Constants.
@@ -58,7 +58,18 @@ class Options extends JMenu implements B4constants
     {
         super(menuname);  
         owner = gjf; 
-
+        
+        JMenuItem newfileItem = new JMenuItem("NewFile");
+        newfileItem.addActionListener(new
+          ActionListener()
+          {
+              public void actionPerformed(ActionEvent ae)
+              {
+                  doNewfileDialog(owner); 
+              }  
+          });
+        this.add(newfileItem); 
+          
         JMenuItem inoutItem = new JMenuItem("InOut"); 
         inoutItem.addActionListener(new
           ActionListener()
@@ -342,7 +353,35 @@ class Options extends JMenu implements B4constants
 
 
     //------private dialog methods; each uses JOptionPane--------------
-
+    //------private dialog methods; each uses JOptionPane--------------
+    //------private dialog methods; each uses JOptionPane--------------
+    //------private dialog methods; each uses JOptionPane--------------
+    //------private dialog methods; each uses JOptionPane--------------
+    //------private dialog methods; each uses JOptionPane--------------
+    //------private dialog methods; each uses JOptionPane--------------
+    
+    void doNewfileDialog(JFrame frame)
+    // allows user to choose NewFile skeleton parameters
+    {
+        LabelDataBox nrecordsBox = new LabelDataBox(UO_NEWFILE, 0, NCHARS);
+        LabelDataBox nfieldsBox = new LabelDataBox(UO_NEWFILE, 1, NCHARS); 
+        LabelDataBox nwidthBox = new LabelDataBox(UO_NEWFILE, 2, NCHARS); 
+        
+        int result = JOptionPane.showOptionDialog(frame, 
+           new Object[] {nrecordsBox, nfieldsBox, nwidthBox},
+           "New File Options",
+           JOptionPane.OK_CANCEL_OPTION,
+           JOptionPane.PLAIN_MESSAGE,
+           null, null, null); 
+        if (result == JOptionPane.OK_OPTION)
+        {
+            DMF.reg.putuo(UO_NEWFILE, 0, nrecordsBox.getText());
+            DMF.reg.putuo(UO_NEWFILE, 1, nfieldsBox.getText());            
+            DMF.reg.putuo(UO_NEWFILE, 2, nwidthBox.getText());
+        }
+    }   
+            
+                  
     void doInOutDialog(JFrame frame)
     {
         LabelBitBox rms = new LabelBitBox(UO_IO, 0); 
@@ -368,6 +407,7 @@ class Options extends JMenu implements B4constants
         LabelDataBox el = new LabelDataBox(UO_LAYOUT, 0, NCHARS); 
         LabelDataBox az = new LabelDataBox(UO_LAYOUT, 1, NCHARS); 
         LabelDataBox ar = new LabelDataBox(UO_LAYOUT, 3, NCHARS); 
+        LabelDataBox dx = new LabelDataBox(UO_LAYOUT, 39, NCHARS); // RT13 line 2500
         LabelBitBox  sticky = new LabelBitBox(UO_LAYOUT, 2); 
         
         String title1 = "Which axis is to point upward?";
@@ -390,7 +430,7 @@ class Options extends JMenu implements B4constants
                                   UO_LAYOUT, 15, frame); 
                                   
         int result = JOptionPane.showOptionDialog(frame,
-           new Object[] {el, az, ar, sticky, shading, connect, 
+           new Object[] {el, az, ar, dx, sticky, shading, connect, 
                          retrovis, vert, ax, rb, db,  bhsb}, 
            "Layout Options", 
            JOptionPane.OK_CANCEL_OPTION, 
@@ -403,6 +443,7 @@ class Options extends JMenu implements B4constants
             DMF.reg.putuo(UO_LAYOUT, 1, az.getText()); 
             DMF.reg.putuo(UO_LAYOUT, 2, sticky.isSelected() ? "T" : "F"); 
             DMF.reg.putuo(UO_LAYOUT, 3, ar.getText()); 
+            DMF.reg.putuo(UO_LAYOUT, 39, dx.getText()); 
             for (int i=0; i<6; i++)
               DMF.reg.putuo(UO_LAYOUT, 4+i, vert.isSelected(i) ? "T" : "F"); 
             for (int i=0; i<5; i++)
@@ -470,14 +511,13 @@ class Options extends JMenu implements B4constants
         LabelDataBox wave = new LabelDataBox(UO_PLOT2, 4, NCHARS); 
         BorVertRadioBox spot = new BorVertRadioBox("Dot style", UO_PLOT2, 5, 4); 
         JLabel blank = new JLabel(" "); 
-        BorVertRadioBox rays = new BorVertRadioBox("Which rays", UO_PLOT2, 9, 2); 
-        LabelDataBox other = new LabelDataBox(UO_PLOT2, 11, 3); 
-        LabelBitBox black = new LabelBitBox(UO_PLOT2, 12); 
+        BorVertRadioBox rays = new BorVertRadioBox("Which rays", UO_PLOT2, 9, 2); // 9=Complete; 10=Sufficient
+        LabelBitBox black = new LabelBitBox(UO_PLOT2, 11); 
 
         int result = JOptionPane.showOptionDialog(frame,
            new Object[] {hvar, hran, hlabel, hblank, 
                          vvar, vran, vlabel, vblank, 
-                         wave, spot, blank, rays, other, black}, 
+                         wave, spot, blank, rays, black}, 
            "Plot2Dim Options", 
            JOptionPane.OK_CANCEL_OPTION, 
            JOptionPane.PLAIN_MESSAGE,
@@ -497,8 +537,7 @@ class Options extends JMenu implements B4constants
             for (int i=0; i<2; i++)
               DMF.reg.putuo(UO_PLOT2, 9+i, rays.isSelected(i) ? "T" : "F"); 
 
-            DMF.reg.putuo(UO_PLOT2, 11, other.getText()); 
-            DMF.reg.putuo(UO_PLOT2, 12, black.isSelected() ? "T" : "F"); 
+            DMF.reg.putuo(UO_PLOT2, 11, black.isSelected() ? "T" : "F"); 
 
             updateAllInstances("Plot2Dim"); 
         }
@@ -633,18 +672,18 @@ class Options extends JMenu implements B4constants
 
     void doPlot3Dialog(JFrame frame)
     {
-        LabelDataBox avar = new LabelDataBox(UO_PLOT3, 0, NCHARS); 
-        LabelDataBox aran = new LabelDataBox(UO_PLOT3, 1, NCHARS); 
-        LabelDataBox bvar = new LabelDataBox(UO_PLOT3, 2, NCHARS); 
-        LabelDataBox bran = new LabelDataBox(UO_PLOT3, 3, NCHARS); 
-        LabelDataBox cvar = new LabelDataBox(UO_PLOT3, 4, NCHARS); 
-        LabelDataBox cran = new LabelDataBox(UO_PLOT3, 5, NCHARS); 
+        LabelDataBox avar = new LabelDataBox(UO_PLOT3, 0, NCHARS); // A var
+        LabelDataBox aran = new LabelDataBox(UO_PLOT3, 1, NCHARS); // A span
+        LabelDataBox bvar = new LabelDataBox(UO_PLOT3, 2, NCHARS); // B var
+        LabelDataBox bran = new LabelDataBox(UO_PLOT3, 3, NCHARS); // B span
+        LabelDataBox cvar = new LabelDataBox(UO_PLOT3, 4, NCHARS); // C var
+        LabelDataBox cran = new LabelDataBox(UO_PLOT3, 5, NCHARS); // C span
         LabelBox clabel = new LabelBox("Set any span=0.0 for auto scaling"); 
-        LabelDataBox elev = new LabelDataBox(UO_PLOT3, 6, NCHARS); 
-        LabelDataBox azim = new LabelDataBox(UO_PLOT3, 7, NCHARS); 
-        LabelDataBox wave = new LabelDataBox(UO_PLOT3, 8, NCHARS); 
-        BorHorizRadioBox spot = new BorHorizRadioBox("Dot style", UO_PLOT3, 9, 4); 
-        BorVertRadioBox rays = new BorVertRadioBox("Which rays", UO_PLOT3, 13, 2);  
+        LabelDataBox elev = new LabelDataBox(UO_PLOT3, 6, NCHARS); // elev
+        LabelDataBox azim = new LabelDataBox(UO_PLOT3, 7, NCHARS); // azim
+        LabelDataBox wave = new LabelDataBox(UO_PLOT3, 8, NCHARS); // wavel
+        BorHorizRadioBox spot = new BorHorizRadioBox("Dot style", UO_PLOT3, 9, 4); // 9,10,11,12
+        BorVertRadioBox rays = new BorVertRadioBox("Which rays", UO_PLOT3, 13, 2); // 13=Complete, 14=Sufficient 
         BorHorizStereoBox bhsb = new BorHorizStereoBox("Format", UO_PLOT3, 15, frame); 
 
         int result = JOptionPane.showOptionDialog(frame,
@@ -1146,7 +1185,9 @@ class Options extends JMenu implements B4constants
             //// now try putting the coordinates into place
 
             int errcode = iPut1Drays(igoal, iwhich, dCenter, dSpan, nCount, istartrow); 
-            if (errcode != 0)
+            if (errcode < 0)
+                JOptionPane.showMessageDialog(frame, "Too many rays");             
+            if (errcode > 0)
             {
                 String w[] = {"X", "Y", "Z", "U", "V", "W"}; 
                 char c = (igoal==0) ? '0' : 'g'; 
@@ -1245,7 +1286,11 @@ class Options extends JMenu implements B4constants
             
             int q = iPutRectRays(igoal, iwhich, dCenter1, dSpan1, nCount1, 
                       dCenter2, dSpan2, nCount2, istartrow); 
-            if (q != 0)
+                      
+            if (q < 0)
+                JOptionPane.showMessageDialog(frame, "Too many rays requested"); 
+                
+            if (q > 0)
             {
                 String w1[] = {"X",   "X",  "Y",  "U",   "U",   "V"}; 
                 String w2[] = {",Y", ",Z",  ",Z", ",V",  ",W",  ",W"}; 
@@ -1287,7 +1332,8 @@ class Options extends JMenu implements B4constants
         LabelDataBox off2 = new LabelDataBox(UO_2DCRAY, 7, NCHARS); 
         LabelDataBox radius = new LabelDataBox(UO_2DCRAY, 8, NCHARS); 
         String s3 = "How many concentric circles?";
-        BorderedHexBox bhb = new BorderedHexBox(s3, UO_2DCRAY, 9, 17, 1, frame); 
+        // note: 17 circles = 919 rays; 34 rings = 3571 rays.
+        BorderedHexBox bhb = new BorderedHexBox(s3, UO_2DCRAY, 9, MAXRINGS, 1, frame); 
         JLabel blank = new JLabel(" "); 
         LabelDataBox start = new LabelDataBox(UO_2DCRAY, 10, NCHARS);
 
@@ -1376,7 +1422,8 @@ class Options extends JMenu implements B4constants
         LabelDataBox radius = new LabelDataBox(UO_2DCGAUS, 8, NCHARS); 
 
         String s3 = "How many concentric circles?";
-        BorderedHexBox bhb = new BorderedHexBox(s3, UO_2DCGAUS, 9, 17, 0, frame); 
+        // note: 17 circles = 919 rays; 34 rings = 3571 rays.
+        BorderedHexBox bhb = new BorderedHexBox(s3, UO_2DCGAUS, 9, MAXRINGS, 0, frame); 
         JLabel blank = new JLabel(" "); 
         LabelDataBox start = new LabelDataBox(UO_2DCGAUS, 10, NCHARS); 
 
@@ -1482,6 +1529,8 @@ class Options extends JMenu implements B4constants
     // w chooses which coordinate: x,y,z,u,v,w = 0...5
     {
         int icoord[] = {RX, RY, RZ, RU, RV, RW}; 
+        if (nrays >= MAXRAYS)
+           return -1; 
         if ((w < 0) || (w > 5))
           return 1; 
         int i1 = icoord[w]; 
@@ -1533,6 +1582,10 @@ class Options extends JMenu implements B4constants
     // Used by doRayRectDialog() to make a rectangular ray pattern. 
     // g=1: goals;  g=0: raystarts
     {
+        int nrays = n1*n2; 
+        if (nrays >= MAXRAYS)
+            return -1;
+            
         int icoord1[] = {RX, RX, RY, RU, RU, RV}; 
         int icoord2[] = {RY, RZ, RZ, RV, RW, RW}; 
         if ((w < 0) || (w > 5))
@@ -1545,9 +1598,9 @@ class Options extends JMenu implements B4constants
         if (redit == null)
           return 2; 
 
-        int nrays = n1*n2; 
-        if ((n1<1) || (n2<1) || (nrays>999))
+        if ((n1<1) || (n2<1))
           return 3; 
+
         if ((dS1<=0.0) || (dS2<=0.0))
           return 4; 
        
@@ -1605,6 +1658,7 @@ class Options extends JMenu implements B4constants
                                double d2, double R, int istart)
     // Used by doRayCircDialog() to make circular ray patterns. 
     // g=1: goals;  g=0: raystarts
+    // note: MAXRAYS is enforced via host NRINGS selector
     {
         int icoord1[] = {RX, RX, RY, RU, RU, RV}; 
         int icoord2[] = {RY, RZ, RZ, RV, RW, RW}; 
@@ -1618,8 +1672,6 @@ class Options extends JMenu implements B4constants
         if (redit == null)
           return 2; 
 
-        if ((ncircles<1) || (ncircles>17))
-          return 3; 
         if (R<=0.0)
           return 4; 
        
@@ -1627,7 +1679,6 @@ class Options extends JMenu implements B4constants
         {
             f1 = REJIF.rI2F[i1]; 
             f2 = REJIF.rI2F[i2]; 
-
         }
         else                         // ray goal
         {
@@ -1683,6 +1734,7 @@ class Options extends JMenu implements B4constants
                                double d2, double R, int istart)
     // Used by doRayGausDialog() to make circular Gaussian ray patterns. 
     // g=1: goals;  g=0: raystarts
+    // note: MAXRAYS is enforced via host MAXRINGS
     {
         int icoord1[] = {RX, RX, RY, RU, RU, RV}; 
         int icoord2[] = {RY, RZ, RZ, RV, RW, RW}; 
@@ -1696,8 +1748,6 @@ class Options extends JMenu implements B4constants
         if (redit == null)
           return 2; 
 
-        if ((ncircles<1) || (ncircles>17))
-          return 3; 
         if ((R <= 0.0))
           return 4; 
        

--- a/Sources/RT13.java
+++ b/Sources/RT13.java
@@ -1822,7 +1822,7 @@ class RT13 implements B4constants
         return RROK; 
     }
 
-    static private int iThin(double rayseq[], double surf[])
+    static private int iThin(double ray[], double surf[])
     // CoordBreak CBout output surface method
     // Must copy previous local xyzuvw into this local surface.
     {

--- a/Sources/RT13.java
+++ b/Sources/RT13.java
@@ -1827,6 +1827,7 @@ class RT13 implements B4constants
     // Must copy previous local xyzuvw into this local surface.
     {
       double focal = surf[OFOCAL];
+      int sign = (int) Math.signum(focal);
       double[] r = new double[3];
       double d;
       d = focal / ray[RTWL];
@@ -1834,9 +1835,9 @@ class RT13 implements B4constants
       r[1] = ray[RTVL] * d - ray[RTYL];
       r[2] = focal;
       d = Math.sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
-      ray[RTUL] = r[0] / d;
-      ray[RTVL] = r[1] / d;
-      ray[RTWL] = Math.abs(r[2] / d);
+      ray[RTUL] = sign * r[0] / d;
+      ray[RTVL] = sign * r[1] / d;
+      ray[RTWL] = sign * r[2] / d;
       return RROK; 
     }
 

--- a/Sources/RT13.java
+++ b/Sources/RT13.java
@@ -1791,6 +1791,8 @@ class RT13 implements B4constants
                     return iCBIN(rayseq, surf, g);  // copy previous local uvw
              case OTCBOUT: // CoordBreak output surface 
                     return iCBOUT(rayseq, surf, g); // copy previous local xyzuvw
+             case OTTHIN:
+                    return iThin(rayseq[g],surf);
         }
         return RRNON; 
     }
@@ -1820,6 +1822,19 @@ class RT13 implements B4constants
         return RROK; 
     }
 
+    static private int iThin(double rayseq[], double surf[])
+    // CoordBreak CBout output surface method
+    // Must copy previous local xyzuvw into this local surface.
+    {
+      double focal = surf[OFOCAL];
+      double mx, my;
+      mx = ray[RTUL] / Math.sqrt(1 - Math.pow(ray[RTUL], 2));
+      ray[RTUL] = (mx + ray[RTXL]) / Math.sqrt(Math.pow(focal, 2) + (mx + ray[RTXL]));
+      my = ray[RTVL] / Math.sqrt(1 - Math.pow(ray[RTVL], 2));
+      ray[RTVL] = (my + ray[RTYL]) / Math.sqrt(Math.pow(focal, 2) + (my + ray[RTYL]));
+      ray[RTWL] = Math.sqrt(1 - Math.pow(ray[RTUL], 2) + Math.pow(ray[RTVL], 2));
+      return RROK; 
+    }
 
     static private int iMirror(double ray[], double surf[])
     // M.Lampton STELLAR SOFTWARE (C) 1989, 2003 

--- a/Sources/RT13.java
+++ b/Sources/RT13.java
@@ -1903,7 +1903,7 @@ class RT13 implements B4constants
     // Jaime García @gvJaime 2019
     // Ray tracing according to thin lens hypothesis.
     {
-      double focal = surf[OFOCAL];
+      double focal = 1 / surf[OFOCAL];
       int sign = (int) Math.signum(focal);
       double[] r = new double[3];
       double d;

--- a/Sources/RT13.java
+++ b/Sources/RT13.java
@@ -1828,11 +1828,11 @@ class RT13 implements B4constants
     {
       double focal = surf[OFOCAL];
       double mx, my;
-      mx = ray[RTUL] / Math.sqrt(1 - Math.pow(ray[RTUL], 2));
-      ray[RTUL] = (mx + ray[RTXL]) / Math.sqrt(Math.pow(focal, 2) + (mx + ray[RTXL]));
-      my = ray[RTVL] / Math.sqrt(1 - Math.pow(ray[RTVL], 2));
-      ray[RTVL] = (my + ray[RTYL]) / Math.sqrt(Math.pow(focal, 2) + (my + ray[RTYL]));
-      ray[RTWL] = Math.sqrt(1 - Math.pow(ray[RTUL], 2) + Math.pow(ray[RTVL], 2));
+      mx = focal * ray[RTUL] / Math.sqrt(1 - Math.pow(ray[RTUL], 2));
+      my = focal * ray[RTVL] / Math.sqrt(1 - Math.pow(ray[RTVL], 2));
+      ray[RTUL] = (mx - ray[RTXL]) / Math.sqrt(Math.pow(focal, 2) + Math.pow((mx - ray[RTXL]), 2));
+      ray[RTVL] = (my - ray[RTYL]) / Math.sqrt(Math.pow(focal, 2) + Math.pow((my - ray[RTYL]), 2));
+      ray[RTWL] = Math.sqrt(1 - Math.pow(ray[RTUL], 2) - Math.pow(ray[RTVL], 2));
       return RROK; 
     }
 

--- a/Sources/RT13.java
+++ b/Sources/RT13.java
@@ -1827,12 +1827,16 @@ class RT13 implements B4constants
     // Must copy previous local xyzuvw into this local surface.
     {
       double focal = surf[OFOCAL];
-      double mx, my;
-      mx = focal * ray[RTUL] / Math.sqrt(1 - Math.pow(ray[RTUL], 2));
-      my = focal * ray[RTVL] / Math.sqrt(1 - Math.pow(ray[RTVL], 2));
-      ray[RTUL] = (mx - ray[RTXL]) / Math.sqrt(Math.pow(focal, 2) + Math.pow((mx - ray[RTXL]), 2));
-      ray[RTVL] = (my - ray[RTYL]) / Math.sqrt(Math.pow(focal, 2) + Math.pow((my - ray[RTYL]), 2));
-      ray[RTWL] = Math.sqrt(1 - Math.pow(ray[RTUL], 2) - Math.pow(ray[RTVL], 2));
+      double[] r = new double[3];
+      double d;
+      d = focal / ray[RTWL];
+      r[0] = ray[RTUL] * d - ray[RTXL];
+      r[1] = ray[RTVL] * d - ray[RTYL];
+      r[2] = focal;
+      d = Math.sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
+      ray[RTUL] = r[0] / d;
+      ray[RTVL] = r[1] / d;
+      ray[RTWL] = Math.abs(r[2] / d);
       return RROK; 
     }
 

--- a/Sources/RT13.java
+++ b/Sources/RT13.java
@@ -1903,7 +1903,10 @@ class RT13 implements B4constants
     // Jaime García @gvJaime 2019
     // Ray tracing according to thin lens hypothesis.
     {
-      double focal = 1 / surf[OFOCAL];
+      double focal = surf[ODIOP];
+      if (focal == 0) return RROK; // if the value is unparsed, or is 0, leave rays unbent.
+      // Invert focal for calculations.
+      focal = 1 / focal;
       int sign = (int) Math.signum(focal);
       double[] r = new double[3];
       double d;

--- a/Sources/RT13.java
+++ b/Sources/RT13.java
@@ -1900,8 +1900,8 @@ class RT13 implements B4constants
     }
 
     static private int iThin(double ray[], double surf[])
-    // CoordBreak CBout output surface method
-    // Must copy previous local xyzuvw into this local surface.
+    // Jaime García @gvJaime 2019
+    // Ray tracing according to thin lens hypothesis.
     {
       double focal = surf[OFOCAL];
       int sign = (int) Math.signum(focal);

--- a/Sources/Random.java
+++ b/Sources/Random.java
@@ -24,12 +24,13 @@ import javax.swing.*;
   *    + add random rays to a MTF
   *
   * 
-  *  Uses RT13 for rayseq[][] and runray().
-  *  Actually, no random rays are generated herein,
-  *  nor are any ray calculations are performed here.
-  *  This routine's client panel simply manages RT13 ray number zero.
-  *  All the math work is done within RT13.
-  *  Only the kickoff management is done here. 
+  * 
+  *  For each random ray, this timer task requests that the
+  *  owner "targetPanel.doRandomRay()" and return True or False. 
+  *
+  *  The targetPanel gets results by requesting RT13.bRunRandomRay(),
+  *  and then uses RT13.dGetRay(0, hsurf, hattr) to gather each point. 
+  *  Only the kickoff management and scorekeeping is done here. 
   *
   *
   *  @author: M.Lampton (c) 2003 STELLAR SOFTWARE all rights reserved.

--- a/Sources/Triple.java
+++ b/Sources/Triple.java
@@ -1,6 +1,6 @@
 package com.stellarsoftware.beam;
 
-/**  Revised 7 Oct 2015 for improved accuracy
+/**  Revised 7 Oct 2015 for improved accuracy:
   *  Replaced arccos(dotProduct) with arctan2(crossProduct, dotProduct); 
   */
 

--- a/Sources/U.java
+++ b/Sources/U.java
@@ -206,6 +206,11 @@ class U implements B4constants
     {
         return 1.0/x == Double.NEGATIVE_INFINITY;
     }
+    
+    static boolean isNotNegZero(double x)
+    {
+        return 1.0/x != Double.NEGATIVE_INFINITY; 
+    }
 
     static double sqr(double x) 
     {


### PR DESCRIPTION
# Overview

This pull request implements perfect thin lenses into BEAM FOUR, to allow for afocal designs such as telescopes, infinity corrected microscopes, microscope eyepieces, and so on.

It creates a new type of surface called "Thin" and a new attribute called "Focus". The new surface redirects the rays as if it was a perfect lens. That means absolutely no new aberrations introduced into the system.

# Changes to the code

It creates an OTTHIN flag and a OFOCAL flag in B4constraints.java, it adds a condition for those in the parser in OEJIF.java, and implements a new ``iThin()`` method in the RT13.java raytracer.

# Mathematics

The ray tracing function has been implemented understanding the lens as an application that converts ray entry angles into positions onto the focal plane. An incoming ray is then launched towards it's assigned position in the focal plane. However, we need the angles of the output ray **u'** = (u', v', w'), rather than a position of the focal plane. Therefore we need to obtain the vector as follows:

* Note that all the vectors are expressed on the lens' local coordinate system.
* Let **u** = (u, v, w) be the unitary vector containing the direction cosines of the incoming ray. And let f be the focal length of our lens.
* Let **q** be a vector that contains the coordinates of the point in the lens in which the incoming ray landed.
* Let **P** be a vector that has the same direction as the incoming ray, but emerges from the center of the lens and lands on the focal plane. 
    * Because all parallel rays focus into a single point, and rays passing through the center don't get bend; this **P** vector represents the coordinates of the point in the focal plane assigned to that direction. 
    * The only coordinate we know is the third coordinate, because the focal plane is one focal length from the lens, so **P** = (Px, Py, f).
    * We can know the rest of the coodinates because **u** is also the unitary vector for **P**. 
        * That way ||**P**|| = f / w. and therefore **P** = ||**P**|| * **u**.
* Let **r** be a vector that goes from the incoming ray landing point, to the point assigned to that direction (that is, **P**).
    * Because we had **q** as the coordinates of the landing point, we have **r** = **P** - **q**.
* The angles of our output ray are the ones of **r**, so: **u'** = **r** / ||**r**||.
* To prevent the rays from going backwards in the case of negative focal lengths, **u'** is multiplied by the signature of f, so actually **u'** = sgn(f) * **r** / ||**r**|| .

# What has been tested

This implementation has been successfully tested for oblique parallel ray focus, and for perfect object refocus.

# Known issues

* Mixing this lenses with other parameters hasn't been tested or filtered. The user is supposed to behave.
    * This implementation does not prevent the user from making a non planar perfect lens.
* Focal lengths cannot be autoadjusted.
* For some reason, sometimes the diameter of the lens won't go over twice the focal length.

# Additional notes

* If the commit sequence inside this pull request doesn't adjust to the commit etiquette of this repo, I can squash all the commits into one, and remake this pull request.
* Code style has been as respected as much as possible.
* Compiled and tested with `javac 1.8.0_212`. The version of javac hasn't been changed in B4constants.java.
* In case this get's merged, I can add this new entity into the documentation.